### PR TITLE
fix: replacer should work with minify enabled

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -15,19 +15,19 @@ export type StringifyReplacerFunction = (
 
 export interface StringifyOptions {
   extended?: boolean | { enable: boolean; relaxed?: boolean };
-  minify?: false | { whitespace?: boolean; key?: boolean };
+  minify?: boolean | { enable: boolean; keyMap?: Record<string, string> };
   compress?: boolean | { enable: boolean };
 }
 
 interface _StringifyOptions {
   extended: { enable: boolean; relaxed: boolean };
-  minify: { whitespace: boolean; key: boolean };
+  minify: { enable: boolean; keyMap: Record<string, string> | undefined };
   compress: { enable: boolean };
 }
 
 const defaultOptions: _StringifyOptions = {
   extended: { enable: false, relaxed: true },
-  minify: { whitespace: false, key: false },
+  minify: { enable: false, keyMap: undefined },
   compress: { enable: false },
 };
 
@@ -52,13 +52,13 @@ function mergeWithDefaultOptions(input?: StringifyOptions): _StringifyOptions {
     input.minify = defaultOptions.minify;
   } else if (typeof input.minify === 'boolean') {
     input.minify = {
-      whitespace: input.minify,
-      key: defaultOptions.minify.key,
+      enable: input.minify,
+      keyMap: defaultOptions.minify.keyMap,
     };
   } else {
     input.minify = {
-      whitespace: input.minify.whitespace ?? defaultOptions.minify.whitespace,
-      key: input.minify.key ?? defaultOptions.minify.key,
+      enable: input.minify.enable,
+      keyMap: input.minify.keyMap ?? defaultOptions.minify.keyMap,
     };
   }
 
@@ -89,6 +89,9 @@ export function stringify(
 ): string {
   let _replacer: any = undefined;
   if (Array.isArray(replacer)) {
+    replacer = replacer
+      .map((key) => key?.toString?.())
+      .filter((key) => key != null);
     _replacer = replacer satisfies StringifyReplacerArray;
   } else if (typeof replacer === 'function') {
     _replacer = replacer satisfies StringifyReplacerFunction;
@@ -99,12 +102,42 @@ export function stringify(
 
   const _options = mergeWithDefaultOptions(options);
 
-  if (_options.minify.whitespace) {
-    space = undefined;
-  }
+  if (_options.minify.enable) {
+    const keyMap = _options.minify.keyMap ?? getMinifyKeyMap(obj);
+    const reversedKeyMap = reverseKeyMap(keyMap);
+    obj = minifyKeys(obj, keyMap);
+    _replacer = function (key, value) {
+      if (key === '') {
+        return {
+          _jkv: value,
+          _jkm: reversedKeyMap,
+        };
+      }
 
-  if (_options.minify.key) {
-    obj = minifyJsonKeys(obj);
+      if (key === '_jkv' || key === '_jkm') {
+        // ignore the internal keys
+        return value;
+      }
+
+      if (Array.isArray(this)) {
+        // only process inner objects, not the array itself
+        // "key" here is array index, as string
+        return value;
+      }
+
+      const originalKey = reversedKeyMap[key] ?? key;
+      if (Array.isArray(replacer)) {
+        if (!replacer.includes(originalKey)) {
+          // only include original keys specified in the replacer array
+          return undefined;
+        }
+      } else if (typeof replacer === 'function') {
+        // apply replacer with the original key
+        value = replacer.call(this, originalKey, value);
+      }
+
+      return value;
+    } satisfies StringifyReplacerFunction;
   }
 
   let result: string;
@@ -122,16 +155,16 @@ export function stringify(
   return result;
 }
 
-export interface KeyMinifiedJson<T> {
-  _jkv: T;
-  _jkm: Record<string, string>;
+function reverseKeyMap(keyMap: Record<string, string>): Record<string, string> {
+  const reversedKeyMap: Record<string, string> = {};
+  for (const [key, value] of Object.entries(keyMap)) {
+    reversedKeyMap[value] = key;
+  }
+  return reversedKeyMap;
 }
 
-function minifyJsonKeys<T>(obj: T): KeyMinifiedJson<T> {
-  obj = cloneDeep(obj);
-
+function getMinifyKeyMap<T>(obj: T): Record<string, string> {
   const keyMap: Record<string, string> = {};
-  const reverseKeyMap: Record<string, string> = {};
   const keyCounts: Record<string, number> = findAllJsonKeys(obj);
 
   const allKeys = Object.keys(keyCounts);
@@ -160,16 +193,10 @@ function minifyJsonKeys<T>(obj: T): KeyMinifiedJson<T> {
       continue;
     }
 
-    keyMap[minifiedKey] = key;
-    reverseKeyMap[key] = minifiedKey;
+    keyMap[key] = minifiedKey;
   }
 
-  obj = minifyAllKeys(obj, reverseKeyMap);
-
-  return {
-    _jkv: obj,
-    _jkm: keyMap,
-  };
+  return keyMap;
 }
 
 function findAllJsonKeys(
@@ -191,15 +218,27 @@ function findAllJsonKeys(
   return keyCounts;
 }
 
-function minifyAllKeys(obj: any, reverseKeyMap: Record<string, string>): any {
+function minifyKeys(
+  obj: any,
+  keyMap: Record<string, string>,
+  level?: number
+): any {
+  let _level: number;
+  if (level == null || level === 0) {
+    _level = 1;
+    obj = cloneDeep(obj);
+  } else {
+    _level = level + 1;
+  }
+
   if (Array.isArray(obj)) {
     obj.forEach((o, i) => {
-      obj[i] = minifyAllKeys(o, reverseKeyMap);
+      obj[i] = minifyKeys(o, keyMap, _level);
     });
   } else if (obj?.constructor === Object) {
     Object.entries(obj).forEach(([key, value]) => {
-      value = minifyAllKeys(value, reverseKeyMap);
-      const minifiedKey = reverseKeyMap[key];
+      value = minifyKeys(value, keyMap, _level);
+      const minifiedKey = keyMap[key];
       if (typeof minifiedKey === 'string' && minifiedKey.length > 0) {
         obj[minifiedKey] = value;
         delete obj[key];

--- a/test/stringify.perf.test.ts
+++ b/test/stringify.perf.test.ts
@@ -8,7 +8,7 @@ const test = (data: any): void => {
   const [basic, basicDuration] = timer(() => JsonKit.stringify(data));
 
   const [minified, minifiedDuration] = timer(() =>
-    JsonKit.stringify(data, { minify: { key: true } })
+    JsonKit.stringify(data, { minify: true })
   );
 
   const [compressed, compressedDuration] = timer(() =>
@@ -17,7 +17,7 @@ const test = (data: any): void => {
 
   const [minifiedAndCompressed, minifiedAndCompressedDuration] = timer(() =>
     JsonKit.stringify(data, {
-      minify: { key: true },
+      minify: true,
       compress: true,
     })
   );

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -69,17 +69,17 @@ describe('[stringify] basic', () => {
     });
     const optionsFull = JsonKit.stringify(obj, {
       extended: { enable: false },
-      minify: { whitespace: false, key: false },
+      minify: { enable: false },
       compress: { enable: false },
     });
     const optionsDefaultFull = JsonKit.stringify(obj, {
       extended: { enable: true, relaxed: true },
-      minify: { whitespace: false, key: false },
+      minify: { enable: false, keyMap: undefined },
       compress: { enable: true },
     });
     const defaultOptions = JsonKit.stringify(obj, {
       extended: { enable: false, relaxed: true },
-      minify: { whitespace: false, key: false },
+      minify: { enable: false, keyMap: undefined },
       compress: { enable: false },
     });
 
@@ -168,19 +168,39 @@ describe('[stringify] minify', () => {
     normal: 'string',
   };
 
-  it('stringify minify with whitespace only', () => {
+  it('stringify minify without keyMap', () => {
     expect(
-      JsonKit.stringify(obj, null, 2, { minify: { whitespace: true } })
-    ).toEqual(JSON.stringify(obj));
-
-    expect(
-      JsonKit.stringify(obj, null, 2, { minify: { whitespace: false } })
-    ).toEqual(JSON.stringify(obj, null, 2));
+      JsonKit.stringify(
+        obj,
+        ['very-long-name', 'very-long-name-2', 'normal'],
+        0,
+        { minify: { enable: true, keyMap: undefined } }
+      )
+    ).toEqual(
+      '{"_jkv":{"normal":"string","a0":{"a0":"very-long-name","a1":2}},"_jkm":{"a0":"very-long-name","a1":"very-long-name-2"}}'
+    );
   });
 
-  it('stringify minify with key', () => {
-    expect(JsonKit.stringify(obj, { minify: { key: true } })).toEqual(
-      '{"_jkv":{"number":1,"boolean":true,"null":null,"date":"2022-12-01T13:44:15.177Z","arr":[{"a0":{"a0":"very-long-name"}},{"testKeys":{"1":"a","2":"b","3":"c","4":"d","5":"e","6":"f","7":"g","8":"h","9":"i","10":"j","11":"k","12":"l","13":"m","14":"n","15":"o","16":"p","17":"q","18":"r","19":"s","20":"t","21":"u","22":"v","23":"w","24":"x","25":"y","26":"z","a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8,"i":9,"j":10,"k":11,"l":12,"m":13,"n":14,"o":15,"p":16,"q":17,"r":18,"s":19,"t":20,"u":21,"v":22,"w":23,"x":24,"y":25,"z":26},"a1":true}],"normal":"string","a0":{"a0":"very-long-name","a1":2}},"_jkm":{"a0":"very-long-name","a1":"very-long-name-2"}}'
+  it('stringify minify with keyMap', () => {
+    expect(
+      JsonKit.stringify(
+        obj,
+        (key, value) => {
+          if (key === 'undefined') {
+            return 'undefined';
+          }
+          return value;
+        },
+        0,
+        {
+          minify: {
+            enable: true,
+            keyMap: { 'very-long-name': 'vln', 'very-long-name-2': 'vln2' },
+          },
+        }
+      )
+    ).toEqual(
+      '{"_jkv":{"number":1,"boolean":true,"null":null,"undefined":"undefined","date":"2022-12-01T13:44:15.177Z","arr":[{"vln":{"vln":"very-long-name"}},{"testKeys":{"1":"a","2":"b","3":"c","4":"d","5":"e","6":"f","7":"g","8":"h","9":"i","10":"j","11":"k","12":"l","13":"m","14":"n","15":"o","16":"p","17":"q","18":"r","19":"s","20":"t","21":"u","22":"v","23":"w","24":"x","25":"y","26":"z","a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8,"i":9,"j":10,"k":11,"l":12,"m":13,"n":14,"o":15,"p":16,"q":17,"r":18,"s":19,"t":20,"u":21,"v":22,"w":23,"x":24,"y":25,"z":26},"vln2":true}],"normal":"string","vln":{"vln":"very-long-name","vln2":2}},"_jkm":{"vln":"very-long-name","vln2":"very-long-name-2"}}'
     );
   });
 });


### PR DESCRIPTION
Note:
adds support for providing custom `keyMap` for minify